### PR TITLE
Fix oauth

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -121,7 +121,6 @@ module.exports = function (options) {
 
         default:
           var strategy = options.strategies[method];
-          var model = req.getModel();
           if (typeof req.query.partner != 'undefined'){
             req.session.partnerData = {
               courseId: req.query.courseId,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -121,18 +121,31 @@ module.exports = function (options) {
 
         default:
           var strategy = options.strategies[method];
-          var partnerData;
+          var model = req.getModel();
           if (typeof req.query.partner != 'undefined'){
-            options.passport.successRedirect = '/user/addPartnerInfo?courseId=' + req.query.courseId + '&courseName=' + req.query.courseName + '&partner=' + req.query.partner + '&optin=' + req.query.optin;
-            options.partnerData = partnerData;
-          }
+            req.session.partnerData = {
+              courseId: req.query.courseId,
+              courseName: req.query.courseName,
+              partner: req.query.partner,
+              optin: req.query.optin
+            };
+           } 
 
           if (!strategy) {
             return next(new Error('Unknown auth strategy: ' + method));
           } else {
             var conf = strategy.conf || {};
             if (parts[2] === 'callback') {
-              passport.authenticate(method, options.passport)(req, res, function(req, res) {
+              var loginOptions = {};
+              if (req.session.partnerData) {
+                loginOptions.successRedirect = '/user/addPartnerInfo?courseId=' + req.session.partnerData.courseId + '&courseName=' + req.session.partnerData.courseName + '&partner=' + req.session.partnerData.partner + '&optin=' + req.session.partnerData.optin;
+                loginOptions.failureRedirect = options.passport.failureRedirect;
+                loginOptions.registerCallback = options.passport.registerCallback;
+                delete req.session.partnerData; //make sure it doesn't hang around for this user
+              } else {
+                loginOptions = options.passport;
+              }
+              passport.authenticate(method, loginOptions)(req, res, function(req, res) {
                 if (res) {
                   res.redirect(options.passport.successRedirect);
                 }


### PR DESCRIPTION
This fixes an issue where we were storing partner data for times users in the global redirect url for google. This meant that if a user logged in through the partner url, the next google user to log in would get partner data assigned to themselves as well as the data would persist. Now we store it on the session and we delete it from there as soon as we have used it so there is no way for it to stick around.