### PR TITLE
Fix oauth

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -137,7 +137,7 @@ module.exports = function (options) {
             if (parts[2] === 'callback') {
               var loginOptions = {};
               if (req.session.partnerData) {
-                loginOptions.successRedirect = '/user/addPartnerInfo?courseId=' + req.session.partnerData.courseId + '&courseName=' + req.session.partnerData.courseName + '&partner=' + req.session.partnerData.partner + '&optin=' + req.session.partnerData.optin;
+                loginOptions.successRedirect = '/partners/' + req.session.partnerData.partner + '/' + req.session.partnerData.courseId + '/' + req.session.partnerData.courseName + '?optin=' + req.session.partnerData.optin;
                 loginOptions.failureRedirect = options.passport.failureRedirect;
                 loginOptions.registerCallback = options.passport.registerCallback;
                 delete req.session.partnerData; //make sure it doesn't hang around for this user

--- a/lib/session.js
+++ b/lib/session.js
@@ -5,7 +5,6 @@ module.exports = function(options) {
   return function(req, res, next) {
     var model = req.getModel();
     var userId = req.session.userId;
-    //console.log('req.session.user', req.session);
     if (!userId) userId = req.session.userId = model.id();
     model.set('_session.userId', userId);
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -5,6 +5,7 @@ module.exports = function(options) {
   return function(req, res, next) {
     var model = req.getModel();
     var userId = req.session.userId;
+    //console.log('req.session.user', req.session);
     if (!userId) userId = req.session.userId = model.id();
     model.set('_session.userId', userId);
 
@@ -14,7 +15,7 @@ module.exports = function(options) {
       $publicUser = model.at(options.publicCollection + '.' + userId);
       model.fetch($user, $publicUser, function(err) {
         model.set('_session.loggedIn', true);
-        model.set('_session.user', req.session.user);
+        model.set('_session.user', model.get(options.publicCollection + '.' + userId));
         model.unfetch($user, next);
       })
     } else {

--- a/lib/session.js
+++ b/lib/session.js
@@ -14,7 +14,7 @@ module.exports = function(options) {
       $publicUser = model.at(options.publicCollection + '.' + userId);
       model.fetch($user, $publicUser, function(err) {
         model.set('_session.loggedIn', true);
-        model.ref('_session.user', $publicUser);
+        model.set('_session.user', req.session.user);
         model.unfetch($user, next);
       })
     } else {


### PR DESCRIPTION
The redirect path has been altered to use a new route on the client which handles partner updates over ajax rather than with a series of redirects as we used to do. The fix in session changes the base Model method used to store the user data on the Model. The old method fell over if two simultaneous requests to log in over google were made on the test server. Model.ref is not especially performant as it does a load of extra things that .set does not do and it was not needed nor desirable for an operation that happens on every single request.